### PR TITLE
feat: add podman support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Dockerfile, and a CI smoke test.
 | Path | Role |
 |---|---|
 | `Dockerfile` | Single-stage Chainguard node image; installs curl, git, tmux, mise, uv, Python, and pi. Entrypoint synthesises a `/etc/passwd` entry for the runtime UID so tools like SSH can resolve the user. |
-| `tasks/pi/_docker_flags` | Sourced (not executed) by all pi tasks; defines `DOCKER_FLAGS` (security options, volume mounts, env-var forwarding) |
+| `tasks/pi/_docker_flags` | Sourced (not executed) by all pi tasks; defines `DOCKER_FLAGS` (security options, volume mounts, env-var forwarding); detects podman and adds `--userns=keep-id` when needed |
 | `tasks/pi/_default` | `mise run pi` — launches the agent in the container |
 | `tasks/pi/readonly` | `mise run pi:readonly` — launches the agent with the project directory mounted read-only and file-modification tools disabled |
 | `tasks/pi/build` | `mise run pi:build` — builds the Docker image |
@@ -70,6 +70,7 @@ mise run ci      # lint + docker build + smoke test
 - `tasks/pi/_docker_flags` is *sourced*, not executed — no shebang, not executable.
 - `#MISE raw=true` and `#MISE dir="{{cwd}}"` on `_default` and `shell` are intentional: they preserve raw terminal I/O and ensure the container's working directory matches the caller's. Do not remove them.
 - Docker security flags (`--cap-drop=ALL`, `--security-opt=no-new-privileges`, `--user $(id -u):$(id -g)`) are non-negotiable. Do not weaken them.
+- **Podman support:** `tasks/pi/_docker_flags` detects podman via `docker --version` output and adds `--userns=keep-id` to fix TTY ownership errors. The `docker` command must be aliased or symlinked to `podman` for detection to work.
 - `--network=host` appears in `pi:build` on Linux (DNS workaround) and in runtime `DOCKER_FLAGS` when `PI_LOCAL_MODELS=1` is set. It must not appear unconditionally in runtime `DOCKER_FLAGS`.
 - When adding a new provider API key: add it to the `PI_ENV_VARS` array in `tasks/pi/_docker_flags` **and** the auth table in `README.md`.
 - Host-side control variables consumed by `_docker_flags`; not forwarded into the container via `PI_ENV_VARS`:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you use [Claude Code](https://docs.anthropic.com/en/docs/claude-code), Aider,
 ## Prerequisites
 
 - [mise](https://mise.jdx.dev/installing-mise.html) >= 2024.12.0
-- [Docker](https://docs.docker.com/get-docker/) (Desktop on macOS, Engine on Linux)
+- [Docker](https://docs.docker.com/get-docker/) (Desktop on macOS, Engine on Linux) or [Podman](https://podman.io/getting-started/installation) (aliased as `docker`)
 - git
 
 ## Install
@@ -309,6 +309,24 @@ To fix this permanently instead:
 2. Add to `/etc/docker/daemon.json`: `{ "dns": ["<upstream-ip>"] }`
 3. Restart dockerd
 4. Remove the `--network=host` line from `tasks/pi/build`
+
+## Podman support
+
+`pi-less-yolo` works with [Podman](https://podman.io) as a drop-in Docker replacement. Podman is automatically detected when the `docker` command is aliased or symlinked to `podman`.
+
+The runtime adds `--userns=keep-id` when podman is detected, which properly maps user namespaces and avoids TTY ownership errors.
+
+Most Linux distributions provide podman with a `docker` compatibility alias. If you don't have one:
+
+```bash
+# On most systems, create the alias:
+alias docker=podman
+
+# Or symlink (system-wide, requires root):
+sudo ln -s $(which podman) /usr/local/bin/docker
+```
+
+All tasks (`pi`, `pi:readonly`, `pi:build`, `pi:shell`) work identically with podman.
 
 ## Customising the container
 

--- a/tasks/pi/_docker_flags
+++ b/tasks/pi/_docker_flags
@@ -3,6 +3,14 @@
 
 PI_IMAGE="pi-less-yolo:latest"
 
+# Detect if we're using podman instead of docker
+# (podman emits a message when invoked as 'docker')
+DOCKER_CMD="docker"
+DOCKER_VERSION_OUTPUT="$(docker --version 2>&1)"
+if echo "${DOCKER_VERSION_OUTPUT}" | grep -q podman; then
+  DOCKER_CMD="podman"
+fi
+
 docker image inspect "${PI_IMAGE}" > /dev/null 2>&1 || mise run pi:build
 
 # Pre-create so Docker doesn't auto-create it as root (breaking writes by the
@@ -35,6 +43,12 @@ DOCKER_FLAGS=(
   "--env" "TERM=${TERM:-xterm-256color}"
   "--env" "COLORTERM=${COLORTERM:-truecolor}"
 )
+
+# Podman-specific: use --userns=keep-id to properly map the user namespace
+# and avoid "crun: chown `/dev/pts/0`: Invalid argument" errors.
+if [[ "${DOCKER_CMD}" == "podman" ]]; then
+  DOCKER_FLAGS+=("--userns=keep-id")
+fi
 
 # Forward pi-related env vars and API keys if set on the host.
 # Auth file (~/.pi/agent/auth.json) takes priority over these if present.


### PR DESCRIPTION
On systems with Podman instead of Docker, executing 'mise run pi' gives the following error:
`Error: OCI runtime error: crun: chown '/dev/pts/0': Invalid argument`

This PR detects if podman is used and adds `--userns=keep-id` to fix TTY ownership errors.