### PR TITLE
Fixing Python Renovate match strings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,7 +38,8 @@
       "customType": "regex",
       "managerFilePatterns": ["/^Dockerfile$/"],
       "matchStrings": [
-        "uv python install (?<currentValue>[\\d.]+)"
+        "uv python install (?<currentValue>[\\d.]+)",
+        "uv python find (?<currentValue>[\\d.]+)"
       ],
       "depNameTemplate": "python",
       "datasourceTemplate": "github-tags",


### PR DESCRIPTION
This PR fixes the Renovate match strings for Python, to ensure the symbolic link is included.