### PR TITLE
Fix PI_SSH_AGENT=1 on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ PI_SSH_AGENT=1 mise run pi
 
 Or export it in your shell profile to make it permanent.
 
-> **Security note:** a compromised container can authenticate as you to any SSH server your agent has loaded. Review loaded keys with `ssh-add -l` before enabling. On macOS, Docker Desktop exposes the host SSH agent via a fixed path inside the VM — no additional setup is needed beyond setting the variable. On Linux, ensure `ssh-agent` is running and `SSH_AUTH_SOCK` is exported in your shell environment.
+> **Security note:** a compromised container can authenticate as you to any SSH server your agent has loaded. Review loaded keys with `ssh-add -l` before enabling. On macOS, Docker Desktop exposes the host SSH agent via a fixed path inside the VM. The socket is created root-owned with restricted permissions; the root group (GID 0) is added as a supplementary group so the non-root container user can access it — no additional setup is needed. On Linux, ensure `ssh-agent` is running and `SSH_AUTH_SOCK` is exported in your shell environment.
 
 ### Local models (Ollama, LM Studio, vLLM)
 

--- a/tasks/pi/_docker_flags
+++ b/tasks/pi/_docker_flags
@@ -114,10 +114,13 @@ if [[ -n "${PI_SSH_AGENT:-}" ]]; then
     DOCKER_FLAGS+=("--volume" "${HOME}/.ssh/config:/home/piuser/.ssh/config:ro")
   fi
 
-  if [[ "$(uname -s)" == "Darwin" ]]; then
+  if [[ "$(uname -s)" == "Darwin" ]] && [[ "${DOCKER_CMD}" == "docker" ]]; then
+    # Docker Desktop creates the socket root:root 660; add GID 0 so the
+    # non-root user can access it. --cap-drop=ALL limits the exposure.
     DOCKER_FLAGS+=(
       "--mount" "type=bind,src=/run/host-services/ssh-auth.sock,target=/run/host-services/ssh-auth.sock"
       "--env" "SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock"
+      "--group-add" "0"
     )
   elif [[ -S "${SSH_AUTH_SOCK:-}" ]]; then
     DOCKER_FLAGS+=(


### PR DESCRIPTION
This PR fixes #51 by adding GID 0 of macOS Docker use, so that the SSH socket is accessible. `--cap-drop=ALL` and the limited container surface should limit exposure.