### PR TITLE
Fixing Podman detection for symlink or podman-docker package

### DIFF
--- a/.mise/tasks/test/_default
+++ b/.mise/tasks/test/_default
@@ -6,3 +6,4 @@ mise run test:pi
 mise run test:python
 mise run test:limits
 mise run test:readonly
+mise run test:podman-detection

--- a/.mise/tasks/test/podman-detection
+++ b/.mise/tasks/test/podman-detection
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#MISE description="Test _docker_flags detects podman when docker resolves to the podman binary"
+set -euo pipefail
+
+if ! command -v podman &>/dev/null; then
+  echo "  SKIP podman not installed"
+  exit 0
+fi
+
+if ! podman image inspect pi-less-yolo:latest &>/dev/null; then
+  echo "  SKIP pi-less-yolo:latest not in podman image store"
+  exit 0
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Simulate podman aliased as docker.  When podman is invoked as "docker" it
+# outputs "docker version X.Y.Z", so grep-based detection cannot find "podman".
+ln -s "$(command -v podman)" "$tmpdir/docker"
+
+result=$(PATH="$tmpdir:$PATH" bash << 'SHELL'
+set -euo pipefail
+unset PI_CONTAINER_RUNTIME
+source tasks/pi/_docker_flags
+echo "$DOCKER_CMD"
+SHELL
+)
+
+[ "$result" = "podman" ] || { echo "FAIL: expected DOCKER_CMD=podman, got '$result'"; exit 1; }
+echo "  OK detected podman when docker is aliased to the podman binary"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ mise run ci      # lint + docker build + smoke test
 - `tasks/pi/_docker_flags` is *sourced*, not executed — no shebang, not executable.
 - `#MISE raw=true` and `#MISE dir="{{cwd}}"` on `_default` and `shell` are intentional: they preserve raw terminal I/O and ensure the container's working directory matches the caller's. Do not remove them.
 - Docker security flags (`--cap-drop=ALL`, `--security-opt=no-new-privileges`, `--user $(id -u):$(id -g)`) are non-negotiable. Do not weaken them.
-- **Podman support:** `tasks/pi/_docker_flags` detects podman via `docker --version` output and adds `--userns=keep-id` to fix TTY ownership errors. Set `PI_CONTAINER_RUNTIME=podman` to skip detection and use podman explicitly.
+- **Podman support:** `tasks/pi/_docker_flags` detects podman via `docker --version` output (version string) and binary path (`readlink -f`); adds `--userns=keep-id` to fix TTY ownership errors. Shell aliases are not visible in non-interactive scripts; users need the `podman-docker` package, a symlink, or `PI_CONTAINER_RUNTIME=podman`.
 - `--network=host` appears in `pi:build` on Linux (DNS workaround) and in runtime `DOCKER_FLAGS` when `PI_LOCAL_MODELS=1` is set. It must not appear unconditionally in runtime `DOCKER_FLAGS`.
 - When adding a new provider API key: add it to the `PI_ENV_VARS` array in `tasks/pi/_docker_flags` **and** the auth table in `README.md`.
 - Host-side control variables consumed by `_docker_flags`; not forwarded into the container via `PI_ENV_VARS`:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you use [Claude Code](https://docs.anthropic.com/en/docs/claude-code), Aider,
 ## Prerequisites
 
 - [mise](https://mise.jdx.dev/installing-mise.html) >= 2024.12.0
-- [Docker](https://docs.docker.com/get-docker/) (Desktop on macOS, Engine on Linux) or [Podman](https://podman.io/getting-started/installation) (via `PI_CONTAINER_RUNTIME=podman` or aliased as `docker`)
+- [Docker](https://docs.docker.com/get-docker/) (Desktop on macOS, Engine on Linux) or [Podman](https://podman.io/getting-started/installation) (via `PI_CONTAINER_RUNTIME=podman`, the `podman-docker` package, or a symlink)
 - git
 
 ## Install
@@ -312,25 +312,41 @@ To fix this permanently instead:
 
 ## Podman support
 
-`pi-less-yolo` works with [Podman](https://podman.io) as a drop-in Docker replacement. Podman is automatically detected when the `docker` command is aliased or symlinked to `podman`.
+`pi-less-yolo` works with [Podman](https://podman.io) as a drop-in Docker replacement.
+Podman is automatically detected when the `docker` command in PATH resolves to the
+podman binary — either via a compatibility wrapper or a symlink.
 
-The runtime adds `--userns=keep-id` when podman is detected, which properly maps user namespaces and avoids TTY ownership errors.
+The runtime adds `--userns=keep-id` when podman is detected, which properly maps user
+namespaces and avoids TTY ownership errors.
 
-Set `PI_CONTAINER_RUNTIME=podman` to use podman explicitly without an alias:
+Set `PI_CONTAINER_RUNTIME=podman` to use podman explicitly without relying on detection:
 
 ```bash
 PI_CONTAINER_RUNTIME=podman mise run pi
 ```
 
-Alternatively, most Linux distributions provide a `docker` compatibility alias. If you don't have one:
+If you don't have a `docker` compatibility shim, the `podman-docker` package is the
+recommended way to provide one:
 
 ```bash
-# Session alias:
-alias docker=podman
+# Fedora/RHEL:
+sudo dnf install podman-docker
 
-# Or symlink (system-wide, requires root):
+# Ubuntu/Debian:
+sudo apt install podman-docker
+```
+
+Or create a symlink manually (no package required):
+
+```bash
 sudo ln -s "$(which podman)" /usr/local/bin/docker
 ```
+
+> **Note:** Shell aliases (`alias docker=podman`) are only expanded in interactive
+> shells. Mise tasks run as non-interactive bash subprocesses and cannot see aliases
+> defined in your shell profile — see the
+> [Bash manual on Aliases](https://www.gnu.org/software/bash/manual/bash.html#Aliases).
+> Use `PI_CONTAINER_RUNTIME=podman`, the `podman-docker` package, or a symlink instead.
 
 All tasks (`pi`, `pi:readonly`, `pi:build`, `pi:shell`) work identically with podman.
 

--- a/tasks/pi/_docker_flags
+++ b/tasks/pi/_docker_flags
@@ -3,12 +3,16 @@
 
 PI_IMAGE="pi-less-yolo:latest"
 
-# PI_CONTAINER_RUNTIME overrides; otherwise detect by grepping docker --version output.
+# PI_CONTAINER_RUNTIME overrides; otherwise detect podman via version output or binary path.
+# || true: some docker-as-podman shims exit non-zero, which would abort under pipefail.
+# readlink: when podman is symlinked as "docker", it reports "docker version X" not "podman version X".
 if [[ -n "${PI_CONTAINER_RUNTIME:-}" ]]; then
   DOCKER_CMD="${PI_CONTAINER_RUNTIME}"
 else
   DOCKER_CMD="docker"
-  if docker --version 2>&1 | grep -q podman; then
+  detected_version=$(docker --version 2>&1 || true)
+  docker_realpath=$(readlink -f "$(command -v docker || true)" 2>/dev/null || true)
+  if [[ "${detected_version}" == *podman* ]] || [[ "${docker_realpath}" == *podman* ]]; then
     DOCKER_CMD="podman"
   fi
 fi


### PR DESCRIPTION
This PR fixes #58, leveraging a solution from @danone-dev. I added an explicit test for this case, and updated the README to explain that `alias docker=podman` does not work in `mise` due to it being a subshell. Recommended strategies are provided, such as using a symlink or the `podman-docker` package.