### PR TITLE
Updating README to reflect pi:upgrade no longer using PI_VERSION

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Dockerfile, and a CI smoke test.
 | `tasks/pi/readonly` | `mise run pi:readonly` — launches the agent with the project directory mounted read-only and file-modification tools disabled |
 | `tasks/pi/build` | `mise run pi:build` — builds the Docker image |
 | `tasks/pi/shell` | `mise run pi:shell` — opens bash in the container with identical mounts |
-| `tasks/pi/upgrade` | `mise run pi:upgrade` — bumps `ARG PI_VERSION` in `Dockerfile` and rebuilds |
+| `tasks/pi/upgrade` | `mise run pi:upgrade` — bumps the `npm install -g` line in `Dockerfile` and rebuilds |
 | `tasks/pi/health` | `mise run pi:health` — checks mise version, Docker, image, task files, `~/.pi/agent`, and tmux |
 | `.mise/tasks/ci` | `mise run ci` — lint → build → smoke test (local equivalent of CI) |
 | `.mise/tasks/install` | Writes `~/.config/mise/conf.d/pi-less-yolo.toml` to register tasks globally |

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ mise run update
 mise run pi:upgrade
 ```
 
-Fetches the latest `@mariozechner/pi-coding-agent` version from npm, updates `ARG PI_VERSION` in `Dockerfile`, and rebuilds the image.
+Fetches the latest `@mariozechner/pi-coding-agent` version from npm, updates the `npm install -g` line in `Dockerfile`, and rebuilds the image.
 
 ## Health check
 
@@ -359,7 +359,7 @@ To modify the container — adding tools, changing the base image, pinning diffe
 mise run pi:build
 ```
 
-The `ARG PI_VERSION` line at the top of `Dockerfile` controls the pi version. `mise run pi:upgrade` updates it automatically; you can also edit it by hand.
+The `npm install -g` line near the bottom of `Dockerfile` pins the pi version. `mise run pi:upgrade` updates it automatically; you can also edit the version string by hand.
 
 ## Related projects
 


### PR DESCRIPTION
Resolves #70. This was removed to simplify the Dockerfile once Renovate was introduced. `mise run pi:upgrade` still fetches the latest version, updating the Dockerfile directly without relying on the `PI_VERSION` argument.