### PR TITLE
Feature: Allow git to work even when in a repo subdir

### DIFF
--- a/tasks/pi/_docker_flags
+++ b/tasks/pi/_docker_flags
@@ -135,3 +135,28 @@ if [[ -n "${PI_SSH_AGENT:-}" ]]; then
     echo "warning: PI_SSH_AGENT=1 but SSH_AUTH_SOCK is not set or is not a socket — SSH agent forwarding disabled" >&2
   fi
 fi
+
+# If pi is started in a sub-directory of a git repo or in a completely
+# sparate worktree folder, this will mount the common .git dir to /git-data
+# and set GIT_DIR environment variable to use it. This will also volume map
+# the underlying toplevel repo directory (which may just be a worktree), in
+# read-only, so that `git status' won't show a bunch of missing files, etc. and to
+# ensure .gitignore. The current working directory will lay inside as it normally would.
+# If not in a repo, then nothing happens.
+GIT_DIR="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || echo '')"
+GIT_WORK_TREE="$(git rev-parse --show-toplevel 2>/dev/null || echo '')"
+if [[ -n "${GIT_DIR:-}" ]]; then
+
+  DOCKER_FLAGS+=(
+    "--volume" "${GIT_DIR}:/git-data${_PI_WORKDIR_RO:+:ro}"  # :ro set by pi:readonly
+    "--env" "GIT_DIR=/git-data"
+  )
+  # Can't map the same directory twice, only map if working dir not same as git worktree
+  if [[ "$(pwd)" != "${GIT_WORK_TREE}" ]]; then
+    DOCKER_FLAGS+=(
+      "--volume" "${GIT_WORK_TREE}:${GIT_WORK_TREE}:ro"
+      "--env" "GIT_WORK_TREE=${GIT_WORK_TREE}"
+    )
+  fi
+fi
+

--- a/tasks/pi/_docker_flags
+++ b/tasks/pi/_docker_flags
@@ -136,27 +136,27 @@ if [[ -n "${PI_SSH_AGENT:-}" ]]; then
   fi
 fi
 
-# If pi is started in a sub-directory of a git repo or in a completely
-# sparate worktree folder, this will mount the common .git dir to /git-data
-# and set GIT_DIR environment variable to use it. This will also volume map
-# the underlying toplevel repo directory (which may just be a worktree), in
-# read-only, so that `git status' won't show a bunch of missing files, etc. and to
-# ensure .gitignore. The current working directory will lay inside as it normally would.
-# If not in a repo, then nothing happens.
-GIT_DIR="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || echo '')"
-GIT_WORK_TREE="$(git rev-parse --show-toplevel 2>/dev/null || echo '')"
-if [[ -n "${GIT_DIR:-}" ]]; then
-
-  DOCKER_FLAGS+=(
-    "--volume" "${GIT_DIR}:/git-data${_PI_WORKDIR_RO:+:ro}"  # :ro set by pi:readonly
-    "--env" "GIT_DIR=/git-data"
-  )
-  # Can't map the same directory twice, only map if working dir not same as git worktree
-  if [[ "$(pwd)" != "${GIT_WORK_TREE}" ]]; then
+# PI_PARENT_GIT_MOUNT=1: mount the repo's common .git dir when pi is launched
+# from a subdirectory or a separate worktree. Sets GIT_DIR and GIT_WORK_TREE
+# inside the container so git commands work correctly. The .git dir is always
+# mounted read-only. If you need the agent to commit, it should do so through
+# the working-tree path.
+if [[ -n "${PI_PARENT_GIT_MOUNT:-}" ]]; then
+  _pi_git_common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  _pi_git_work_tree="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "${_pi_git_common_dir}" ]]; then
     DOCKER_FLAGS+=(
-      "--volume" "${GIT_WORK_TREE}:${GIT_WORK_TREE}:ro"
-      "--env" "GIT_WORK_TREE=${GIT_WORK_TREE}"
+      "--volume" "${_pi_git_common_dir}:/git-data${_PI_WORKDIR_RO:+:ro}"  # :ro set by pi:readonly
+      "--env" "GIT_DIR=/git-data"
     )
+    # Mount the worktree root read-only only when it isn't already covered by
+    # the primary $(pwd):$(pwd) mount — i.e. launching from a subdirectory or
+    # a linked worktree whose root differs from the working directory.
+    if [[ "$(pwd -P)" != "${_pi_git_work_tree}" ]]; then
+      DOCKER_FLAGS+=(
+        "--volume" "${_pi_git_work_tree}:${_pi_git_work_tree}:ro"
+        "--env" "GIT_WORK_TREE=${_pi_git_work_tree}"
+      )
+    fi
   fi
 fi
-


### PR DESCRIPTION
When in a sub-directory of a repo when start `pi`, then no `git` commands work for that repo.  This means that pi agents cannot see the history, status, etc. to help make set better context.

The reason this happens is because the .git folder will be in a sub-directory, or for some worktrees completely different directory structure. And when pi-less-yolo starts in subdirectory the .git folder and other files not in current working directory will not be mounted.

As an example from below tree, if pi-less-yolo is kicked off from `/my-project/src/somedir`, then git will not work.  If started from /my-project then git will work.

```
/my-project 
+ -- .git 
+ -- src 
++ -- somedir 
```

And if started from a worktree of my-project in a separate directory, the /my-project/.git is also needed because that is where the git data is stored.

This PR discovers if pi-less-yolo was started in a git repo, and discovers the common git data dir, maps that into `/git-data`, and sets environment variable to tell git to look there for the git data.  It follows the same PI_WORKDIR_RO rules that the user selects.

Then if the user does not start in the worktree dir, then the full worktree dir is volume mapped into the container - but always READONLY.  Without the rest of the repo directories, things like `git status` will make it look like all the files were deleted, and this solves for that by having the files visible now.

