### PR TITLE
Update pi-coding-agent repo for earendil-works/pi

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,14 +91,14 @@ mise run ci      # lint + docker build + smoke test
 
 ### Renovate
 
-`renovate.json` uses `config:recommended` and applies a 72-hour minimum release age to all dependencies except `@mariozechner/pi-coding-agent`. It disables Docker image digest and GitHub Actions managers (handled by Dependabot) and uses four `regexManagers` to track versions in `Dockerfile` and `README.md`:
+`renovate.json` uses `config:recommended` and applies a 72-hour minimum release age to all dependencies except `@earendil-works/pi-coding-agent`. It disables Docker image digest and GitHub Actions managers (handled by Dependabot) and uses four `regexManagers` to track versions in `Dockerfile` and `README.md`:
 
 | Dependency | Location | Datasource |
 |---|---|---|
 | `mise` | `MISE_VERSION=` in `Dockerfile` | GitHub Releases (`jdx/mise`) |
 | `uv` | `mise install uv@` / `mise exec uv@` in `Dockerfile` | GitHub Releases (`astral-sh/uv`) |
 | Python | `uv python install <ver>` in `Dockerfile` | GitHub Tags (`python/cpython`) |
-| `@mariozechner/pi-coding-agent` | `npm install -g` line in `Dockerfile` and badge in `README.md` | npm |
+| `@earendil-works/pi-coding-agent` | `npm install -g` line in `Dockerfile` and badge in `README.md` | npm |
 
 Both `Dockerfile` and `README.md` must be updated together when pi's version changes (Renovate handles both via the same `matchStrings` list).
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN uv python install 3.14.4 \
     && ln -s "$(uv python find 3.14.4)" /usr/local/bin/python3
 
 # Install pi globally
-RUN npm install -g "@mariozechner/pi-coding-agent@0.73.1"
+RUN npm install -g "@earendil-works/pi-coding-agent@0.74.0"
 
 # Prepend extension binaries (host-mounted via /pi-agent). Security: binaries
 # here can shadow any command; no privilege escalation (--cap-drop=ALL,

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # pi-less-yolo
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![pi version](https://img.shields.io/badge/pi--coding--agent-0.73.1-blueviolet)](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent)
+[![pi version](https://img.shields.io/badge/pi--coding--agent-0.74.0-blueviolet)](https://github.com/earendil-works/pi/tree/main/packages/coding-agent)
 [![Base Image](https://img.shields.io/badge/base%20image-chainguard%2Fnode-F4835E?logo=docker)](https://images.chainguard.dev/directory/image/node/overview)
 [![Dependabot](https://img.shields.io/badge/Dependabot-enabled-brightgreen?logo=dependabot)](https://github.com/cjermain/pi-less-yolo/blob/main/.github/dependabot.yml)
 [![mise](https://mise-versions.jdx.dev/badge.svg)](https://mise.jdx.dev)
 [![CI](https://img.shields.io/github/actions/workflow/status/cjermain/pi-less-yolo/ci.yml?style=flat&label=CI)](https://github.com/cjermain/pi-less-yolo/actions/workflows/ci.yml)
 
-> Run [pi-coding-agent](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) (a multi-provider AI coding agent supporting Claude, GPT, Gemini, and [many more](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent#providers--models)) inside an isolated Docker container — limiting the blast radius of agent-driven changes to your mounted working directory.
+> Run [pi-coding-agent](https://github.com/earendil-works/pi/tree/main/packages/coding-agent) (a multi-provider AI coding agent supporting Claude, GPT, Gemini, and [many more](https://github.com/earendil-works/pi/tree/main/packages/coding-agent#providers--models)) inside an isolated Docker container — limiting the blast radius of agent-driven changes to your mounted working directory.
 
 ![pi-less-yolo demo: filesystem isolation proof and AI-assisted bug fix](docs/demo.gif)
 
@@ -136,7 +136,7 @@ mise run update
 mise run pi:upgrade
 ```
 
-Fetches the latest `@mariozechner/pi-coding-agent` version from npm, updates the `npm install -g` line in `Dockerfile`, and rebuilds the image.
+Fetches the latest `@earendil-works/pi-coding-agent` version from npm, updates the `npm install -g` line in `Dockerfile`, and rebuilds the image.
 
 ## Health check
 
@@ -197,7 +197,7 @@ The following environment variables are forwarded from your host into the contai
 
 Pi config variables (`PI_SKIP_VERSION_CHECK`, `PI_CACHE_RETENTION`, `PI_PACKAGE_DIR`) and editor variables (`VISUAL`, `EDITOR`) are also forwarded. No other host environment variables are passed into the container.
 
-**Auth file** (`~/.pi/agent/auth.json`): credentials stored here take priority over environment variables. Use `/login` inside pi to set this up interactively. See [pi's provider docs](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/providers.md) for details.
+**Auth file** (`~/.pi/agent/auth.json`): credentials stored here take priority over environment variables. Use `/login` inside pi to set this up interactively. See [pi's provider docs](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/providers.md) for details.
 
 ## Security model
 
@@ -379,7 +379,7 @@ The `npm install -g` line near the bottom of `Dockerfile` pins the pi version. `
 
 ## Related projects
 
-- [pi-coding-agent](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) — the upstream AI coding agent this repo wraps
+- [pi-coding-agent](https://github.com/earendil-works/pi) — the upstream AI coding agent this repo wraps
 - [mise](https://mise.jdx.dev) — the polyglot dev-tool manager used for task running
 - [Chainguard Images](https://chainguard.dev) — minimal, hardened container base images used here
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) — Anthropic's official sandboxed coding agent CLI, a similar concept

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
       "enabled": false
     },
     {
-      "matchDepNames": ["@mariozechner/pi-coding-agent"],
+      "matchDepNames": ["@earendil-works/pi-coding-agent"],
       "minimumReleaseAge": null
     }
   ],
@@ -53,7 +53,7 @@
         "pi-coding-agent@(?<currentValue>[\\d.]+)",
         "pi--coding--agent-(?<currentValue>[\\d.]+)-blueviolet"
       ],
-      "depNameTemplate": "@mariozechner/pi-coding-agent",
+      "depNameTemplate": "@earendil-works/pi-coding-agent",
       "datasourceTemplate": "npm"
     }
   ]

--- a/tasks/pi/upgrade
+++ b/tasks/pi/upgrade
@@ -12,7 +12,7 @@ DOCKER_CMD="${PI_CONTAINER_RUNTIME:-docker}"
 }
 
 CURRENT=$(perl -ne 'print $1 if /pi-coding-agent@([\d.]+)/' "${DOCKERFILE}")
-LATEST=$("${DOCKER_CMD}" run --rm --entrypoint npm "${PI_IMAGE}" view @mariozechner/pi-coding-agent version)
+LATEST=$("${DOCKER_CMD}" run --rm --entrypoint npm "${PI_IMAGE}" view @earendil-works/pi-coding-agent version)
 
 if [[ "${CURRENT}" == "${LATEST}" ]]; then
   echo "Already at latest pi version: ${CURRENT}"


### PR DESCRIPTION
This PR updates the references to point to the new repo for pi-coding-agent: https://github.com/earendil-works/pi