### PR TITLE
feat(docker): add PI_EXTRA_MOUNTS for custom volume mounts

### DIFF
--- a/.mise/tasks/test/_default
+++ b/.mise/tasks/test/_default
@@ -6,4 +6,5 @@ mise run test:pi
 mise run test:python
 mise run test:limits
 mise run test:readonly
+mise run test:extra-mounts
 mise run test:podman-detection

--- a/.mise/tasks/test/extra-mounts
+++ b/.mise/tasks/test/extra-mounts
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#MISE description="Smoke test that PI_EXTRA_MOUNTS mounts host directories with the requested mode, and warns without failing on missing sources or malformed entries"
+set -euo pipefail
+
+src_rw=$(mktemp -d)
+src_ro=$(mktemp -d)
+trap 'rm -rf "$src_rw" "$src_ro"' EXIT
+
+# Default mode (no ":mode" suffix) is rw: a write inside the container must reach the host.
+_inner_rw='
+  echo hello > /extra-rw/marker && echo OK || echo FAIL
+'
+# shellcheck disable=SC2016  # $1 is a positional parameter in the child bash -c, not the current shell
+result_rw=$(
+  PI_EXTRA_MOUNTS="${src_rw}:/extra-rw" bash -c '
+    source tasks/pi/_docker_flags
+    "${DOCKER_CMD}" run "${DOCKER_FLAGS[@]}" pi-less-yolo:latest bash -c "$1"
+  ' -- "$_inner_rw"
+)
+[ "$result_rw" = "OK" ] && [ -f "${src_rw}/marker" ] || { echo "FAIL: rw mount is not writable or not visible on host"; exit 1; }
+echo "  OK default mode is rw and writes reach the host"
+
+# Explicit :ro mode: a write inside the container must fail.
+_inner_ro='
+  touch /extra-ro/marker && echo WRITABLE || echo READONLY
+'
+# shellcheck disable=SC2016  # $1 is a positional parameter in the child bash -c, not the current shell
+result_ro=$(
+  PI_EXTRA_MOUNTS="${src_ro}:/extra-ro:ro" bash -c '
+    source tasks/pi/_docker_flags
+    "${DOCKER_CMD}" run "${DOCKER_FLAGS[@]}" pi-less-yolo:latest bash -c "$1"
+  ' -- "$_inner_ro"
+)
+[ "$result_ro" = "READONLY" ] || { echo "FAIL: :ro mount is writable"; exit 1; }
+echo "  OK :ro mount is read-only"
+
+# Missing source directory: warns and is skipped, task still succeeds (no container run needed).
+warning=$(
+  PI_EXTRA_MOUNTS="/nonexistent-path-for-pi-test:/extra" bash -c '
+    source tasks/pi/_docker_flags
+  ' 2>&1 >/dev/null
+)
+[[ "$warning" == *"not found"* ]] || { echo "FAIL: missing source did not warn"; exit 1; }
+echo "  OK missing source warns and is skipped"
+
+# Malformed entry (no ":target"): warns and is skipped, task still succeeds.
+warning=$(
+  PI_EXTRA_MOUNTS="onlysource" bash -c '
+    source tasks/pi/_docker_flags
+  ' 2>&1 >/dev/null
+)
+[[ "$warning" == *"malformed"* ]] || { echo "FAIL: malformed entry did not warn"; exit 1; }
+echo "  OK malformed entry warns and is skipped"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ mise run ci      # lint + docker build + smoke test
   | `PI_CPUS` | Set `--cpus` |
   | `PI_PIDS_LIMIT` | Set `--pids-limit` |
   | `PI_CONTAINER_RUNTIME` | Override container runtime (e.g. `podman`); skips auto-detection |
+  | `PI_EXTRA_MOUNTS` | `;`-separated `source:target[:mode]` volume mounts; mode defaults to `rw`; malformed entries and missing sources both warn to stderr and are skipped, never fail the task |
 - Use `perl -pi -e` for in-place file edits (cross-platform; avoids `sed -i` / `sed -i ''` incompatibility between Linux and macOS).
 
 ## Automated dependency updates
@@ -111,11 +112,13 @@ Both `Dockerfile` and `README.md` must be updated together when pi's version cha
 
 ## GitHub Actions
 
-`.github/workflows/ci.yml` triggers on push and pull requests to `main`. It has two independent jobs:
+`.github/workflows/ci.yml` triggers on push and pull requests to `main`. It has four jobs:
 
-| Job | Steps |
-|---|---|
-| `lint` | Checkout → mise-action → `mise run lint` |
-| `build` | Checkout → Docker Buildx → build image (GHA cache) → smoke test `--version` → smoke test `python3 --version` |
+| Job | Depends on | Steps |
+|---|---|---|
+| `lint` | — | Checkout → mise-action → `mise run lint` |
+| `build` | — | Checkout → Docker Buildx → build image, exported to `image.tar` (GHA cache) → upload as artifact |
+| `test` | `build` | Checkout → mise-action → download + `docker load` the image → `mise run test` |
+| `test-podman` | `build` | Checkout → mise-action → download + `podman load` the image → `PI_CONTAINER_RUNTIME=podman mise run test` |
 
-The build job uses `docker/build-push-action` with `push: false` and `load: true` so the built image is available for the smoke tests without being pushed to a registry.
+The build job uses `docker/build-push-action` with `push: false` and `outputs: type=docker` so the built image can be uploaded as an artifact and reused by both test jobs without a registry.

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN uv python install 3.14.4 \
     && ln -s "$(uv python find 3.14.4)" /usr/local/bin/python3
 
 # Install pi globally
-RUN npm install -g "@earendil-works/pi-coding-agent@0.78.0"
+RUN npm install -g "@earendil-works/pi-coding-agent@0.80.3"
 
 # Prepend extension binaries (host-mounted via /pi-agent). Security: binaries
 # here can shadow any command; no privilege escalation (--cap-drop=ALL,

--- a/README.md
+++ b/README.md
@@ -298,6 +298,24 @@ Or export it in your shell profile to make it permanent.
 > `host.docker.internal` as the `baseUrl` in `models.json` instead — Docker
 > Desktop routes that hostname to the Mac host correctly.
 
+### Extra mounts
+
+Set `PI_EXTRA_MOUNTS` to mount additional host directories into the container —
+for example an LLM wiki, shared agent config, or SSH keys — without editing
+`DOCKER_FLAGS` directly:
+
+```bash
+export PI_EXTRA_MOUNTS="$HOME/.llm-wiki:/home/piuser/.llm-wiki;$HOME/.agents:/home/piuser/.agents:ro"
+```
+
+Format: `source:target[:mode]`, entries separated by `;`. `mode` is `rw` (default) or
+`ro`. Malformed entries and sources that don't exist on the host both print a warning
+and are skipped — they don't stop pi from starting.
+
+> **Security note:** the default mode is `rw`, so the agent can write to any mounted
+> directory unless you add `:ro`. Only mount directories you're comfortable with the
+> agent modifying.
+
 ### Resource limits
 
 By default no memory, CPU, or process-count limits are applied. Set any of these

--- a/tasks/pi/_docker_flags
+++ b/tasks/pi/_docker_flags
@@ -104,6 +104,32 @@ if [[ -n "${PI_LOCAL_MODELS:-}" ]]; then
   DOCKER_FLAGS+=("--network=host")
 fi
 
+# PI_EXTRA_MOUNTS: semicolon-separated list of additional directory mounts.
+# Format: source_path:container_path[:mode]
+#   source — absolute path on the host (use $HOME, not ~)
+#   target — path inside the container
+#   mode   — rw (default) or ro
+# Example:
+#   export PI_EXTRA_MOUNTS="$HOME/.llm-wiki:/home/piuser/.llm-wiki;$HOME/.agents:/home/piuser/.agents"
+if [[ -n "${PI_EXTRA_MOUNTS:-}" ]]; then
+  _pi_ifs="$IFS"
+  IFS=';'
+  for _pi_spec in ${PI_EXTRA_MOUNTS}; do
+    _pi_src="${_pi_spec%%:*}"
+    _pi_rest="${_pi_spec#*:}"
+    _pi_tgt="${_pi_rest%%:*}"
+    _pi_mode="${_pi_rest#*:}"
+    [[ "${_pi_mode}" == "${_pi_rest}" ]] && _pi_mode="rw"
+    if [[ -e "${_pi_src}" ]]; then
+      DOCKER_FLAGS+=("--volume" "${_pi_src}:${_pi_tgt}:${_pi_mode}")
+    else
+      echo "warning: PI_EXTRA_MOUNTS source '${_pi_src}' not found — skipping mount" >&2
+    fi
+  done
+  IFS="$_pi_ifs"
+  unset _pi_ifs _pi_spec _pi_src _pi_rest _pi_tgt _pi_mode
+fi
+
 # SSH agent forwarding. Opt in by setting PI_SSH_AGENT=1.
 # Also mounts ~/.ssh/known_hosts and ~/.ssh/config read-only.
 # Security: a compromised container can authenticate as you to any server your

--- a/tasks/pi/_docker_flags
+++ b/tasks/pi/_docker_flags
@@ -115,19 +115,23 @@ if [[ -n "${PI_EXTRA_MOUNTS:-}" ]]; then
   _pi_ifs="$IFS"
   IFS=';'
   for _pi_spec in ${PI_EXTRA_MOUNTS}; do
-    _pi_src="${_pi_spec%%:*}"
-    _pi_rest="${_pi_spec#*:}"
-    _pi_tgt="${_pi_rest%%:*}"
-    _pi_mode="${_pi_rest#*:}"
-    [[ "${_pi_mode}" == "${_pi_rest}" ]] && _pi_mode="rw"
-    if [[ -e "${_pi_src}" ]]; then
-      DOCKER_FLAGS+=("--volume" "${_pi_src}:${_pi_tgt}:${_pi_mode}")
+    [[ -z "${_pi_spec}" ]] && continue  # tolerate stray/trailing ';'
+
+    if [[ "${_pi_spec}" =~ ^([^:]+):([^:]+)(:(rw|ro))?$ ]]; then
+      _pi_src="${BASH_REMATCH[1]}"
+      _pi_tgt="${BASH_REMATCH[2]}"
+      _pi_mode="${BASH_REMATCH[4]:-rw}"
+      if [[ -e "${_pi_src}" ]]; then
+        DOCKER_FLAGS+=("--volume" "${_pi_src}:${_pi_tgt}:${_pi_mode}")
+      else
+        echo "warning: PI_EXTRA_MOUNTS source '${_pi_src}' not found — skipping mount" >&2
+      fi
     else
-      echo "warning: PI_EXTRA_MOUNTS source '${_pi_src}' not found — skipping mount" >&2
+      echo "warning: PI_EXTRA_MOUNTS entry '${_pi_spec}' is malformed (expected source:target[:rw|ro]) — skipping" >&2
     fi
   done
   IFS="$_pi_ifs"
-  unset _pi_ifs _pi_spec _pi_src _pi_rest _pi_tgt _pi_mode
+  unset _pi_ifs _pi_spec _pi_src _pi_tgt _pi_mode
 fi
 
 # SSH agent forwarding. Opt in by setting PI_SSH_AGENT=1.


### PR DESCRIPTION
## Summary

Adds `PI_EXTRA_MOUNTS` — a semicolon-separated env variable for mounting additional host directories into the sandbox container, following the same pattern as the existing `PI_LOCAL_MODELS`.

## Motivation

Users who need to mount LLM wikis, agent configs, SSH keys, or other host directories into the sandbox previously had to edit `DOCKER_FLAGS` directly or override the whole task. This env var provides a clean, declarative interface.

## Usage

```bash
export PI_EXTRA_MOUNTS="$HOME/.llm-wiki:/home/piuser/.llm-wiki;$HOME/.agents:/home/piuser/.agents:ro"
```

Format: `source_path:container_path[:mode]` — mode defaults to `rw`, entries separated by `;`. Missing sources print a warning and are skipped.

## Changes

| Commit | Description |
|--------|-------------|
| cf37847 | `feat(docker): add PI_EXTRA_MOUNTS for custom volume mounts` |
| 1590e02 | `build(deps): bump pi-coding-agent to 0.80.3` |

## Checklist

- [x] ShellCheck passes on `tasks/pi/_docker_flags`
- [x] Follows existing `PI_LOCAL_MODELS` pattern for flag-building logic